### PR TITLE
AUDIT-31 Improve audit log readability by hiding null and "Unable to read" values

### DIFF
--- a/omod/src/main/webapp/resources/scripts/auditlog.js
+++ b/omod/src/main/webapp/resources/scripts/auditlog.js
@@ -113,18 +113,36 @@ function displayLogDetails(logDetails, isChildLog){
                 otherDataCount++;
                 var currentProperty = auditLogChanges[propertyName];
                 if(isUpdate){
-                    $j("#"+auditlog_moduleId+idPart+"-changes-table tr:last").after(
-                        "<tr>" +
-                            "<td class=\"auditlog_align_text_left\" valign=\"top\">"+propertyName+"</td>"+
-                            "<td class=\"auditlog_align_text_left\" valign=\"top\">"+currentProperty[0]+"</td>"+
-                            "<td class=\"auditlog_align_text_left\" valign=\"top\">"+currentProperty[1]+"</td>" +
-                            "</tr>");
+
+                    var newVal = currentProperty[0];
+                    var oldVal = currentProperty[1];
+
+                    if(!newVal || newVal === "Unable to read"){
+                        newVal = "";
+                    }
+
+                   if(!oldVal || oldVal === "Unable to read"){
+                        oldVal = "";
+                    }
+
+                   $j("#"+auditlog_moduleId+idPart+"-changes-table tr:last").after(
+                      "<tr>" +
+                      "<td class=\"auditlog_align_text_left\" valign=\"top\">"+propertyName+"</td>"+
+                      "<td class=\"auditlog_align_text_left\" valign=\"top\">"+newVal+"</td>"+
+                      "<td class=\"auditlog_align_text_left\" valign=\"top\">"+oldVal+"</td>" +
+                      "</tr>");
                 }else{
+                   var val = currentProperty;
+
+                   if(!val || val === "Unable to read"){
+                        val = "";
+                    }
                     $j("#"+auditlog_moduleId+idPart+"-delete-otherData-table tr:last").after(
-                        "<tr>" +
-                            "<td class=\"auditlog_align_text_left\" valign=\"top\">"+propertyName+"</td>"+
-                            "<td class=\"auditlog_align_text_left\" valign=\"top\">"+currentProperty+"</td>" +
-                            "</tr>");
+                    "<tr>" +
+                    "<td class=\"auditlog_align_text_left\" valign=\"top\">"+propertyName+"</td>"+
+                    "<td class=\"auditlog_align_text_left\" valign=\"top\">"+val+"</td>"+
+                    "</tr>");
+                   
                 }
             });
 


### PR DESCRIPTION
## Description
This PR improves the readability of the audit log details page.

Previously the UI displayed values like "Unable to read" or null for many properties,
which made the audit log difficult to interpret.

This change sanitizes values in auditlog.js before rendering them,
replacing null or "Unable to read" with empty strings.

## Issue
AUDIT-31