### PR TITLE
AUDIT-29 Fix voided resources not showing changes in audit table

### DIFF
--- a/omod/src/main/webapp/resources/scripts/auditlog.js
+++ b/omod/src/main/webapp/resources/scripts/auditlog.js
@@ -95,7 +95,7 @@ function displayLogDetails(logDetails, isChildLog){
         if (logDetails.objectExists == true) {
             $j("#" + auditlog_moduleId + idPart + "-changes-summary").html(logDetails.displayString);
         }
-        else if (logDetails.action != 'DELETED') {
+        else if (logDetails.action != 'DELETED' && logDetails.action != 'VOIDED') {
             $j("#" + auditlog_moduleId + idPart + "-changes-summary").html("<span class='auditlog_deleted'>" + auditlog_messages.objectDoesnotExit + "</span>");
         }
 
@@ -106,8 +106,12 @@ function displayLogDetails(logDetails, isChildLog){
             $j("#" + auditlog_moduleId + idPart + "-changes-openmrsVersion").html(logDetails.openmrsVersion);
         }
         if(logDetails.changes){
+            if(Object.keys(logDetails.changes).length === 0){
+                $j("#"+auditlog_moduleId+idPart+"-changes-table").show();
+                return;
+                    }
             var auditLogChanges = logDetails.changes;
-            var isUpdate = logDetails.action == 'UPDATED' ? true : false;
+            var isUpdate = (logDetails.action == 'UPDATED' || logDetails.action == 'VOIDED');
             var otherDataCount = 0;
             $j.each(auditLogChanges, function(propertyName){
                 otherDataCount++;

--- a/omod/src/main/webapp/resources/scripts/auditlog.js
+++ b/omod/src/main/webapp/resources/scripts/auditlog.js
@@ -93,17 +93,19 @@ function displayLogDetails(logDetails, isChildLog){
     $j("#"+auditlog_moduleId+idPart+"-delete-otherData-table").hide();
     if(logDetails) {
         if (logDetails.objectExists == true) {
-            $j("#" + auditlog_moduleId + idPart + "-changes-summary").html(logDetails.displayString);
+            $j("#" + auditlog_moduleId + idPart + "-changes-summary").text(logDetails.displayString || '');
         }
         else if (logDetails.action != 'DELETED' && logDetails.action != 'VOIDED') {
-            $j("#" + auditlog_moduleId + idPart + "-changes-summary").html("<span class='auditlog_deleted'>" + auditlog_messages.objectDoesnotExit + "</span>");
+            $j("#" + auditlog_moduleId + idPart + "-changes-summary").html("<span class='auditlog_deleted'></span>");
+
+           $j("#" + auditlog_moduleId + idPart + "-changes-summary span").text(auditlog_messages.objectDoesnotExit || '');
         }
 
         if (logDetails.identifier) {
-            $j("#" + auditlog_moduleId + idPart + "-changes-identifier").html(logDetails.identifier);
+            $j("#" + auditlog_moduleId + idPart + "-changes-identifier").text(logDetails.identifier || '');
         }
         if (logDetails.openmrsVersion) {
-            $j("#" + auditlog_moduleId + idPart + "-changes-openmrsVersion").html(logDetails.openmrsVersion);
+            $j("#" + auditlog_moduleId + idPart + "-changes-openmrsVersion").text(logDetails.openmrsVersion || '');
         }
         if(logDetails.changes){
             if(Object.keys(logDetails.changes).length === 0){


### PR DESCRIPTION
This PR addresses AUDIT-29.

Previously, when a resource was voided or retired, a modification entry was created in the audit log, but no changes were visible in the UI.

Root cause:
- VOIDED actions were not handled correctly in the UI logic.
- When no changes were present, the table was not displayed.

Fix:
- Added handling for VOIDED action similar to UPDATED.
- Ensured the changes table is shown even when no changes are present.
- Replaced unsafe .html() usage with safer rendering (.text() and controlled HTML) to prevent potential XSS risks.

This improves usability and ensures audit logs correctly reflect voided resource actions.