### PR TITLE
Fix incorrect @param Javadoc in AuditLogService interface

### DIFF
--- a/api/src/main/java/org/openmrs/module/auditlog/AuditLog.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/AuditLog.java
@@ -13,6 +13,11 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "auditlog_audit_log")
+/**
+ * Represents a single audit log entry recording a change made to an audited object.
+ * Each entry captures the type of action, the affected object, the user responsible,
+ * and the timestamp of the change.
+ */
 public class AuditLog implements Serializable {
 
 	private static final long serialVersionUID = 1L;

--- a/api/src/main/java/org/openmrs/module/auditlog/api/AuditLogService.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/api/AuditLogService.java
@@ -144,7 +144,7 @@ public interface AuditLogService extends OpenmrsService {
 	/**
 	 * Gets all audit logs for the object that match the other specified arguments
 	 * 
-	 * @param object the uuid of the object to match against
+	 * @param object id the id of the object to match against
 	 * @param actions the actions to match against
 	 * @param startDate the start date to match against
 	 * @param endDate the end date to match against


### PR DESCRIPTION
The @param tag for the `id` parameter in `getAuditLogs()` incorrectly described it as "the uuid to match against" — copied from the method above it. 
Updated to accurately describe it as the object id.