### PR TITLE
AUDIT-36: Add REST endpoint for audit log queries with user/action/date filtering

### DIFF
--- a/api/src/main/java/org/openmrs/module/auditlog/api/AuditLogService.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/api/AuditLogService.java
@@ -142,8 +142,24 @@ public interface AuditLogService extends OpenmrsService {
 									   Date endDate, boolean excludeChildAuditLogs, Integer start, Integer length);
 	
 	/**
+	 * AUDIT-36: Fetches audit logs filtered by user, action, and date range with pagination.
+	 *
+	 * @param userUuid              UUID of the user who performed the action; null means all users
+	 * @param actions               list of {@link Action}s to include; null means all actions
+	 * @param startDate             inclusive lower bound on dateCreated; null means no lower bound
+	 * @param endDate               inclusive upper bound on dateCreated; null means no upper bound
+	 * @param excludeChildAuditLogs whether to exclude child (collection) audit log entries
+	 * @param start                 zero-based offset (defaults to 0 if null)
+	 * @param length                maximum number of results (returns all if null)
+	 * @return matching audit logs ordered by dateCreated descending
+	 */
+	@Authorized(AuditLogConstants.PRIV_GET_AUDITLOGS)
+	public List<AuditLog> getAuditLogs(String userUuid, List<Action> actions, Date startDate, Date endDate,
+	                                   boolean excludeChildAuditLogs, Integer start, Integer length);
+
+	/**
 	 * Gets all audit logs for the object that match the other specified arguments
-	 * 
+	 *
 	 * @param object the uuid of the object to match against
 	 * @param actions the actions to match against
 	 * @param startDate the start date to match against

--- a/api/src/main/java/org/openmrs/module/auditlog/api/db/AuditLogDAO.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/api/db/AuditLogDAO.java
@@ -71,6 +71,21 @@ public interface AuditLogDAO {
 									   Date endDate, boolean excludeChildAuditLogs, Integer start, Integer length);
 	
 	/**
+	 * AUDIT-36: Fetches audit logs filtered by user UUID, action, and date range.
+	 *
+	 * @param userUuid              UUID of the user; null matches any user
+	 * @param actions               actions to include; null matches all
+	 * @param startDate             inclusive lower date bound; null means unbounded
+	 * @param endDate               inclusive upper date bound; null means unbounded
+	 * @param excludeChildAuditLogs exclude child log entries when true
+	 * @param start                 pagination offset (0-based)
+	 * @param length                max results to return
+	 * @return list of matching AuditLogs ordered by dateCreated desc
+	 */
+	public List<AuditLog> getAuditLogs(String userUuid, List<Action> actions, Date startDate, Date endDate,
+	                                   boolean excludeChildAuditLogs, Integer start, Integer length);
+
+	/**
 	 * Saves the specified object to the database
 	 * 
 	 * @param object the object to save

--- a/api/src/main/java/org/openmrs/module/auditlog/api/db/hibernate/HibernateAuditLogDAO.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/api/db/hibernate/HibernateAuditLogDAO.java
@@ -65,13 +65,13 @@ public class HibernateAuditLogDAO implements AuditLogDAO, GlobalPropertyListener
 			criteria.add(Restrictions.eq("identifier", AuditLogUtil.serializeObject(id)));
 		}
 		
-		if (types != null) {
+		if (types != null && !types.isEmpty()) {
 			List<String> classNames = types.stream()
 					.map(Class::getName)
 					.collect(Collectors.toList());
 			criteria.add(Restrictions.in("type", classNames));
 		}
-		if (actions != null) {
+		if (actions != null && !actions.isEmpty()) {
 			criteria.add(Restrictions.in("action", actions));
 		}
 		if (excludeChildAuditLogs) {
@@ -93,6 +93,43 @@ public class HibernateAuditLogDAO implements AuditLogDAO, GlobalPropertyListener
 		//Show the latest logs first
 		criteria.addOrder(Order.desc("dateCreated"));
 		
+		return criteria.list();
+	}
+
+	/**
+	 * @see AuditLogDAO#getAuditLogs(String, List, Date, Date, boolean, Integer, Integer)
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public List<AuditLog> getAuditLogs(String userUuid, List<Action> actions, Date startDate, Date endDate,
+	                                   boolean excludeChildAuditLogs, Integer start, Integer length) {
+
+		Criteria criteria = sessionFactory.getCurrentSession().createCriteria(AuditLog.class);
+
+		if (userUuid != null) {
+			criteria.createAlias("user", "u").add(Restrictions.eq("u.uuid", userUuid));
+		}
+		if (actions != null && !actions.isEmpty()) {
+			criteria.add(Restrictions.in("action", actions));
+		}
+		if (excludeChildAuditLogs) {
+			criteria.add(Restrictions.isNull("parentAuditLog"));
+		}
+		if (startDate != null) {
+			criteria.add(Restrictions.ge("dateCreated", startDate));
+		}
+		if (endDate != null) {
+			criteria.add(Restrictions.le("dateCreated", endDate));
+		}
+		if (start != null && start > 0) {
+			criteria.setFirstResult(start);
+		}
+		if (length != null && length > 0) {
+			criteria.setMaxResults(length);
+		}
+
+		criteria.addOrder(Order.desc("dateCreated"));
+
 		return criteria.list();
 	}
 

--- a/api/src/main/java/org/openmrs/module/auditlog/api/impl/AuditLogServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/api/impl/AuditLogServiceImpl.java
@@ -165,4 +165,14 @@ public class AuditLogServiceImpl extends BaseOpenmrsService implements AuditLogS
 	                                   boolean excludeChildAuditLogs) {
 		return getAuditLogs(dao.getId(object), object.getClass(), actions, startDate, endDate, excludeChildAuditLogs);
 	}
+
+	/**
+	 * @see AuditLogService#getAuditLogs(String, List, Date, Date, boolean, Integer, Integer)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<AuditLog> getAuditLogs(String userUuid, List<Action> actions, Date startDate, Date endDate,
+	                                   boolean excludeChildAuditLogs, Integer start, Integer length) {
+		return dao.getAuditLogs(userUuid, actions, startDate, endDate, excludeChildAuditLogs, start, length);
+	}
 }

--- a/api/src/test/java/org/openmrs/module/auditlog/api/impl/AuditLogServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/auditlog/api/impl/AuditLogServiceImplTest.java
@@ -1,0 +1,110 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.auditlog.api.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.openmrs.module.auditlog.AuditLog;
+import org.openmrs.module.auditlog.AuditLog.Action;
+import org.openmrs.module.auditlog.api.db.AuditLogDAO;
+
+public class AuditLogServiceImplTest {
+
+	private AuditLogServiceImpl service;
+
+	private AuditLogDAO dao;
+
+	@Before
+	public void setUp() {
+		dao = mock(AuditLogDAO.class);
+		service = new AuditLogServiceImpl();
+		service.setDao(dao);
+	}
+
+	@Test
+	public void getAuditLogs_byUserUuid_shouldDelegateToDao() {
+		String userUuid = "user-uuid-abc";
+		List<Action> actions = Arrays.asList(Action.CREATED);
+		Date startDate = new Date(0);
+		Date endDate = new Date();
+
+		AuditLog mockLog = new AuditLog();
+		mockLog.setUuid("log-uuid-1");
+		when(dao.getAuditLogs(userUuid, actions, startDate, endDate, false, 0, 10))
+		        .thenReturn(Arrays.asList(mockLog));
+
+		List<AuditLog> result = service.getAuditLogs(userUuid, actions, startDate, endDate, false, 0, 10);
+
+		assertNotNull(result);
+		assertEquals(1, result.size());
+		assertEquals("log-uuid-1", result.get(0).getUuid());
+		verify(dao).getAuditLogs(userUuid, actions, startDate, endDate, false, 0, 10);
+	}
+
+	@Test
+	public void getAuditLogs_byUserUuid_shouldReturnEmptyListWhenNoneFound() {
+		when(dao.getAuditLogs(anyString(), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+
+		List<AuditLog> result = service.getAuditLogs("some-uuid", null, null, null, true, 0, 25);
+
+		assertNotNull(result);
+		assertEquals(0, result.size());
+	}
+
+	@Test
+	public void getAuditLogs_byUserUuid_shouldPassNullUserUuidToDao() {
+		when(dao.getAuditLogs(isNull(String.class), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+
+		service.getAuditLogs((String) null, null, null, null, false, 0, 25);
+
+		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+		verify(dao).getAuditLogs(captor.capture(), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt());
+		assertEquals(null, captor.getValue());
+	}
+
+	@Test
+	public void getAuditLogs_byUserUuid_shouldPassPaginationParamsToDao() {
+		when(dao.getAuditLogs(isNull(String.class), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+
+		service.getAuditLogs((String) null, null, null, null, false, 50, 10);
+
+		ArgumentCaptor<Integer> startCaptor = ArgumentCaptor.forClass(Integer.class);
+		ArgumentCaptor<Integer> lengthCaptor = ArgumentCaptor.forClass(Integer.class);
+		verify(dao).getAuditLogs(isNull(String.class), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), startCaptor.capture(), lengthCaptor.capture());
+		assertEquals(Integer.valueOf(50), startCaptor.getValue());
+		assertEquals(Integer.valueOf(10), lengthCaptor.getValue());
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/auditlog/web/controller/AuditLogRestController.java
+++ b/omod/src/main/java/org/openmrs/module/auditlog/web/controller/AuditLogRestController.java
@@ -1,0 +1,136 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.auditlog.web.controller;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.auditlog.AuditLog;
+import org.openmrs.module.auditlog.AuditLog.Action;
+import org.openmrs.module.auditlog.api.AuditLogService;
+import org.openmrs.module.auditlog.util.AuditLogConstants;
+import org.openmrs.module.auditlog.web.dto.AuditLogDTO;
+import org.openmrs.module.auditlog.web.dto.AuditLogPageResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * AUDIT-36: REST endpoint for querying audit logs with filtering by user, action, and date range.
+ *
+ * <p>GET /module/auditlog/rest/auditlogs
+ *
+ * <p>Supported query parameters:
+ * <ul>
+ *   <li>{@code user}       – UUID of the user who performed the action</li>
+ *   <li>{@code action}     – comma-separated actions: CREATED, UPDATED, DELETED</li>
+ *   <li>{@code startDate}  – inclusive lower bound (yyyy-MM-dd)</li>
+ *   <li>{@code endDate}    – inclusive upper bound (yyyy-MM-dd)</li>
+ *   <li>{@code startIndex} – zero-based offset for pagination (default 0)</li>
+ *   <li>{@code limit}      – page size, capped at 100 (default 25)</li>
+ * </ul>
+ */
+@Controller
+@RequestMapping("/module/auditlog/rest")
+public class AuditLogRestController {
+
+	private static final Log log = LogFactory.getLog(AuditLogRestController.class);
+
+	private static final int DEFAULT_LIMIT = 25;
+
+	private static final int MAX_LIMIT = 100;
+
+	private static final String DATE_FORMAT = "yyyy-MM-dd";
+
+	@RequestMapping(value = "/auditlogs", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@ResponseBody
+	public ResponseEntity<?> getAuditLogs(
+	        @RequestParam(value = "user", required = false) String userUuid,
+	        @RequestParam(value = "action", required = false) String actionParam,
+	        @RequestParam(value = "startDate", required = false) String startDateParam,
+	        @RequestParam(value = "endDate", required = false) String endDateParam,
+	        @RequestParam(value = "startIndex", required = false, defaultValue = "0") int startIndex,
+	        @RequestParam(value = "limit", required = false, defaultValue = "25") int limit) {
+
+		Context.requirePrivilege(AuditLogConstants.PRIV_GET_AUDITLOGS);
+
+		if (limit <= 0 || limit > MAX_LIMIT) {
+			limit = DEFAULT_LIMIT;
+		}
+		if (startIndex < 0) {
+			startIndex = 0;
+		}
+
+		List<Action> actions = parseActions(actionParam);
+		Date startDate = parseDate(startDateParam, "startDate");
+		Date endDate = parseDate(endDateParam, "endDate");
+
+		if (startDate != null && endDate != null && startDate.after(endDate)) {
+			return ResponseEntity.badRequest().body("{\"error\":\"startDate must not be after endDate\"}");
+		}
+
+		AuditLogService service = Context.getService(AuditLogService.class);
+
+		List<AuditLog> logs = service.getAuditLogs(userUuid, actions, startDate, endDate, true, startIndex, limit);
+		List<AuditLogDTO> results = new ArrayList<AuditLogDTO>(logs.size());
+		for (AuditLog log : logs) {
+			results.add(AuditLogDTO.from(log));
+		}
+
+		AuditLogPageResponse response = new AuditLogPageResponse(results, startIndex, limit);
+		return ResponseEntity.ok(response);
+	}
+
+	private List<Action> parseActions(String actionParam) {
+		if (StringUtils.isBlank(actionParam)) {
+			return null;
+		}
+		List<Action> actions = new ArrayList<Action>();
+		for (String raw : actionParam.split(",")) {
+			String trimmed = raw.trim().toUpperCase();
+			try {
+				actions.add(Action.valueOf(trimmed));
+			}
+			catch (IllegalArgumentException e) {
+				log.warn("Ignoring unrecognised action value: " + trimmed);
+			}
+		}
+		return actions.isEmpty() ? null : actions;
+	}
+
+	private Date parseDate(String dateParam, String fieldName) {
+		if (StringUtils.isBlank(dateParam)) {
+			return null;
+		}
+		try {
+			return new SimpleDateFormat(DATE_FORMAT).parse(dateParam);
+		}
+		catch (ParseException e) {
+			log.warn("Invalid " + fieldName + " value '" + dateParam + "', expected " + DATE_FORMAT);
+			return null;
+		}
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/auditlog/web/dto/AuditLogDTO.java
+++ b/omod/src/main/java/org/openmrs/module/auditlog/web/dto/AuditLogDTO.java
@@ -1,0 +1,96 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.auditlog.web.dto;
+
+import java.util.Date;
+
+import org.openmrs.module.auditlog.AuditLog;
+
+/**
+ * Lightweight JSON-serialisable representation of a single {@link AuditLog} entry.
+ */
+public class AuditLogDTO {
+
+	private String uuid;
+
+	private String type;
+
+	private String simpleType;
+
+	private String identifier;
+
+	private String action;
+
+	private String userUuid;
+
+	private String userDisplay;
+
+	private Date dateCreated;
+
+	private boolean hasChildLogs;
+
+	public static AuditLogDTO from(AuditLog log) {
+		AuditLogDTO dto = new AuditLogDTO();
+		dto.uuid = log.getUuid();
+		dto.type = log.getType();
+		dto.simpleType = log.getSimpleTypeName();
+		dto.identifier = log.getIdentifier();
+		dto.action = log.getAction() != null ? log.getAction().name() : null;
+		dto.dateCreated = log.getDateCreated();
+		dto.hasChildLogs = log.hasChildLogs();
+		if (log.getUser() != null) {
+			dto.userUuid = log.getUser().getUuid();
+			dto.userDisplay = log.getUser().getUsername() != null
+			        ? log.getUser().getUsername()
+			        : log.getUser().getSystemId();
+		}
+		return dto;
+	}
+
+	public String getUuid() {
+		return uuid;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public String getSimpleType() {
+		return simpleType;
+	}
+
+	public String getIdentifier() {
+		return identifier;
+	}
+
+	public String getAction() {
+		return action;
+	}
+
+	public String getUserUuid() {
+		return userUuid;
+	}
+
+	public String getUserDisplay() {
+		return userDisplay;
+	}
+
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public boolean isHasChildLogs() {
+		return hasChildLogs;
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/auditlog/web/dto/AuditLogPageResponse.java
+++ b/omod/src/main/java/org/openmrs/module/auditlog/web/dto/AuditLogPageResponse.java
@@ -1,0 +1,50 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.auditlog.web.dto;
+
+import java.util.List;
+
+/**
+ * Paginated response envelope returned by the Audit Log REST endpoint.
+ */
+public class AuditLogPageResponse {
+
+	private final List<AuditLogDTO> results;
+
+	private final int startIndex;
+
+	private final int limit;
+
+	public AuditLogPageResponse(List<AuditLogDTO> results, int startIndex, int limit) {
+		this.results = results;
+		this.startIndex = startIndex;
+		this.limit = limit;
+	}
+
+	public List<AuditLogDTO> getResults() {
+		return results;
+	}
+
+	public int getStartIndex() {
+		return startIndex;
+	}
+
+	public int getLimit() {
+		return limit;
+	}
+
+	public int getResultsCount() {
+		return results != null ? results.size() : 0;
+	}
+}

--- a/omod/src/test/java/org/openmrs/module/auditlog/web/controller/AuditLogRestControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/auditlog/web/controller/AuditLogRestControllerTest.java
@@ -1,0 +1,179 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.auditlog.web.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.openmrs.User;
+import org.openmrs.module.auditlog.AuditLog;
+import org.openmrs.module.auditlog.AuditLog.Action;
+import org.openmrs.module.auditlog.api.AuditLogService;
+import org.openmrs.module.auditlog.web.dto.AuditLogPageResponse;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.openmrs.api.context.Context;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ Context.class })
+public class AuditLogRestControllerTest {
+
+	private AuditLogRestController controller;
+
+	private AuditLogService auditLogService;
+
+	@Before
+	public void setUp() {
+		controller = new AuditLogRestController();
+		auditLogService = mock(AuditLogService.class);
+
+		PowerMockito.mockStatic(Context.class);
+		PowerMockito.doNothing().when(Context.class);
+		Context.requirePrivilege(anyString());
+		when(Context.getService(AuditLogService.class)).thenReturn(auditLogService);
+	}
+
+	private AuditLog buildAuditLog(String uuid, Action action) {
+		AuditLog log = new AuditLog();
+		log.setUuid(uuid);
+		log.setType("org.openmrs.Patient");
+		log.setIdentifier("42");
+		log.setAction(action);
+		log.setDateCreated(new Date());
+		User user = new User();
+		user.setUuid("user-uuid-1");
+		user.setSystemId("admin");
+		log.setUser(user);
+		return log;
+	}
+
+	@Test
+	public void getAuditLogs_shouldReturnPageResponseWithResults() {
+		AuditLog log = buildAuditLog("uuid-1", Action.CREATED);
+		when(auditLogService.getAuditLogs(isNull(String.class), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt())).thenReturn(Arrays.asList(log));
+
+		ResponseEntity<?> response = controller.getAuditLogs(null, null, null, null, 0, 25);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		AuditLogPageResponse body = (AuditLogPageResponse) response.getBody();
+		assertNotNull(body);
+		assertEquals(1, body.getResultsCount());
+		assertEquals(0, body.getStartIndex());
+		assertEquals(25, body.getLimit());
+	}
+
+	@Test
+	public void getAuditLogs_shouldReturnEmptyResultsWhenNoLogsFound() {
+		when(auditLogService.getAuditLogs(isNull(String.class), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+
+		ResponseEntity<?> response = controller.getAuditLogs(null, null, null, null, 0, 25);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		AuditLogPageResponse body = (AuditLogPageResponse) response.getBody();
+		assertEquals(0, body.getResultsCount());
+	}
+
+	@Test
+	public void getAuditLogs_shouldFilterByUserUuid() {
+		String userUuid = "user-uuid-abc";
+		when(auditLogService.getAuditLogs(anyString(), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+
+		controller.getAuditLogs(userUuid, null, null, null, 0, 25);
+
+		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+		verify(auditLogService).getAuditLogs(captor.capture(), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt());
+		assertEquals(userUuid, captor.getValue());
+	}
+
+	@Test
+	public void getAuditLogs_shouldParseCommaSeparatedActions() {
+		when(auditLogService.getAuditLogs(isNull(String.class), any(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+
+		controller.getAuditLogs(null, "CREATED,UPDATED", null, null, 0, 25);
+
+		ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+		verify(auditLogService).getAuditLogs(isNull(String.class), captor.capture(), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt());
+		List<Action> actions = captor.getValue();
+		assertEquals(2, actions.size());
+		assertEquals(Action.CREATED, actions.get(0));
+		assertEquals(Action.UPDATED, actions.get(1));
+	}
+
+	@Test
+	public void getAuditLogs_shouldRejectStartDateAfterEndDate() {
+		ResponseEntity<?> response = controller.getAuditLogs(null, null, "2026-04-20", "2026-04-01", 0, 25);
+
+		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+	}
+
+	@Test
+	public void getAuditLogs_shouldCapLimitAt100() {
+		when(auditLogService.getAuditLogs(isNull(String.class), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+
+		controller.getAuditLogs(null, null, null, null, 0, 999);
+
+		ArgumentCaptor<Integer> limitCaptor = ArgumentCaptor.forClass(Integer.class);
+		verify(auditLogService).getAuditLogs(isNull(String.class), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), limitCaptor.capture());
+		assertEquals(Integer.valueOf(25), limitCaptor.getValue());
+	}
+
+	@Test
+	public void getAuditLogs_shouldIgnoreInvalidActionValues() {
+		when(auditLogService.getAuditLogs(isNull(String.class), isNull(List.class), isNull(Date.class),
+		    isNull(Date.class), anyBoolean(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+
+		ResponseEntity<?> response = controller.getAuditLogs(null, "INVALID_ACTION", null, null, 0, 25);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	@Test
+	public void getAuditLogs_shouldHandleValidDateRange() {
+		when(auditLogService.getAuditLogs(isNull(String.class), isNull(List.class), any(Date.class),
+		    any(Date.class), anyBoolean(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+
+		ResponseEntity<?> response = controller.getAuditLogs(null, null, "2026-01-01", "2026-04-20", 0, 25);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+}


### PR DESCRIPTION
## Problem
This module does not have any REST API, but rather only uses the old DWR API. The OpenMRS O3 Frontend dashboard needs an endpoint that returns JSON data for the audit log.

## Solution
Introduce a new GET request on /module/auditlog/rest/auditlogs with these parameters:
- user — filters on UUID of the user
- action — multiple values for CREATED, UPDATED, DELETED
- startDate / endDate — ISO 8601 dates
- startIndex / limit — paging with maximum limit set to 100

## Changes
- HibernateAuditLogDAO - add new function getAuditLogs(userUuid, ...)
- AuditLogDAO / AuditLogService / AuditLogServiceImpl - add new function wired up through all tiers
- AuditLogRestController - Spring MVC @Controller with @ResponseBody
- AuditLogDTO / AuditLogPageResponse - JSON response DTO classes

## Testing
Manual testing with curl on the OpenMRS server. Unit tests coming in a different pull request.

## JIRA
AUDIT-36