### PR TITLE
AUDIT-37: add database indexes on auditlog_audit_log for frequently filtered columns

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -34,6 +34,25 @@
 		 	referencedTableName="users" referencedColumnNames="user_id" />
  	</changeSet>
 
+	<changeSet id="auditlog-20260420-indexes" author="ashthe25">
+		<preConditions onFail="MARK_RAN">
+			<tableExists tableName="auditlog_audit_log" />
+		</preConditions>
+		<comment>AUDIT-37: Add indexes on frequently filtered columns to prevent full table scans</comment>
+		<createIndex tableName="auditlog_audit_log" indexName="idx_auditlog_date_created">
+			<column name="date_created" />
+		</createIndex>
+		<createIndex tableName="auditlog_audit_log" indexName="idx_auditlog_action">
+			<column name="action" />
+		</createIndex>
+		<createIndex tableName="auditlog_audit_log" indexName="idx_auditlog_user_id">
+			<column name="user_id" />
+		</createIndex>
+		<createIndex tableName="auditlog_audit_log" indexName="idx_auditlog_parent_id">
+			<column name="parent_auditlog_id" />
+		</createIndex>
+	</changeSet>
+
 	<changeSet id="create-sequence-auditlog" author="ekirapa">
 		<preConditions onFail="MARK_RAN">
 			<not><sequenceExists sequenceName="audit_log_audit_log_id_seq" /></not>


### PR DESCRIPTION
JIRA Issue: https://issues.openmrs.org/browse/AUDIT-37

No indexes exist in the auditlog_audit_log table for fields such as date_created, action, user_id, or parent_auditlog_id. All queries performed filter operations using these fields; hence, a complete table scan is involved, causing considerable delays on production environments.

The changeset introduces four indexes using Liquibase to improve performance in the following cases:
- idx_auditlog_date_created
- idx_auditlog_action
- idx_auditlog_user_id
- idx_auditlog_parent_id