### PR TITLE
AUDIT-38: fix inverted null check on user in AuditLogListItem causing NullPointerException

### DIFF
--- a/omod/src/main/java/org/openmrs/module/auditlog/web/dwr/AuditLogListItem.java
+++ b/omod/src/main/java/org/openmrs/module/auditlog/web/dwr/AuditLogListItem.java
@@ -51,7 +51,7 @@ public class AuditLogListItem {
 		}
 		identifier = auditLog.getIdentifier();
 		action = auditLog.getAction().toString();
-		if (auditLog.getUser() == null) {
+		if (auditLog.getUser() != null) {
 			if (auditLog.getUser().getUuid().equals(DAEMON_USER_UUID)) {
 				userDetails = Context.getMessageSourceService().getMessage(AuditLogConstants.MODULE_ID + ".systemChange");
 			} else {


### PR DESCRIPTION
JIRA: https://issues.openmrs.org/browse/AUDIT-38

AuditLogListItem line 54 checks `if (auditLog.getUser() == null)` then 
immediately calls `auditLog.getUser().getUuid()` inside that block.

This throws NullPointerException for every audit log created by system 
or daemon processes where user is null.

Fix: invert the condition to `if (auditLog.getUser() != null)`.