### PR TITLE
AUDIT-39: fix resource leak in AuditLogUtil.getAsString by using try-with-resources

### DIFF
--- a/api/src/main/java/org/openmrs/module/auditlog/util/AuditLogUtil.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/util/AuditLogUtil.java
@@ -273,11 +273,12 @@ public class AuditLogUtil {
 	}
 	
 	public static String getAsString(Blob blob) throws Exception {
-		BufferedReader br = new BufferedReader(new InputStreamReader(blob.getBinaryStream()));
-		StringBuffer sb = new StringBuffer();
-		String line;
-		while ((line = br.readLine()) != null) {
-			sb.append(line);
+		StringBuilder sb = new StringBuilder();
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(blob.getBinaryStream()))) {
+			String line;
+			while ((line = br.readLine()) != null) {
+				sb.append(line);
+			}
 		}
 		return sb.toString();
 	}


### PR DESCRIPTION
JIRA: https://issues.openmrs.org/browse/AUDIT-39

BufferedReader in AuditLogUtil.getAsString is never closed if an exception 
occurs during reading, causing a resource leak.

Fix: wrap with try-with-resources to guarantee the reader is closed in 
all code paths. Also replaced StringBuffer with StringBuilder as no 
synchronization is needed here.