### PR TITLE
AUDIT-41: add depth limit to recursive save() in HibernateAuditLogDAO

### DIFF
--- a/api/src/main/java/org/openmrs/module/auditlog/api/db/hibernate/HibernateAuditLogDAO.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/api/db/hibernate/HibernateAuditLogDAO.java
@@ -136,17 +136,21 @@ public class HibernateAuditLogDAO implements AuditLogDAO, GlobalPropertyListener
 	 */
 	@Override
 	public <T> T save(T object) {
+		saveInternal(object, 0);
+		return object;
+	}
+
+	private void saveInternal(Object object, int depth) {
+		if (depth > 50) {
+			throw new IllegalStateException("AuditLog parent chain exceeds maximum depth of 50; possible cycle detected");
+		}
 		if (object instanceof AuditLog) {
 			AuditLog auditLog = (AuditLog) object;
-			//Hibernate has issues with saving the parentAuditLog field if the parent isn't yet saved
-			//so we need to first save the parent before its children
 			if (auditLog.getParentAuditLog() != null && auditLog.getParentAuditLog().getAuditLogId() == null) {
-				save(auditLog.getParentAuditLog());
+				saveInternal(auditLog.getParentAuditLog(), depth + 1);
 			}
 		}
-		
 		sessionFactory.getCurrentSession().saveOrUpdate(object);
-		return object;
 	}
 	
 	/**


### PR DESCRIPTION
## JIRA
[AUDIT-41](https://openmrs.atlassian.net/browse/AUDIT-41)

## Description
`HibernateAuditLogDAO.save()` recursively saves parent AuditLogs without an unsaved flag set. No upper bound on recursion depth means a circular dependency or deeply nested parents will result in a `StackOverflowError`.

Moved to private helper method `saveInternal(object, depth)` with exception throwing on level 50, well above any realistic recursion depth.

## Testing process
1. Confirm save operation behaves normally.
2. Set up hierarchy of 51 nested parents and confirm `IllegalStateException`, not stack overflow.

[AUDIT-41]: https://openmrs.atlassian.net/browse/AUDIT-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ