### PR TITLE
AUDIT-42: restrict ViewAuditLogController to GET requests only

### DIFF
--- a/omod/src/main/java/org/openmrs/module/auditlog/web/controller/ViewAuditLogController.java
+++ b/omod/src/main/java/org/openmrs/module/auditlog/web/controller/ViewAuditLogController.java
@@ -21,6 +21,7 @@ import org.openmrs.module.auditlog.util.AuditLogConstants;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
  * This class configured as controller using annotation and mapped with the URL of
@@ -38,7 +39,7 @@ public class ViewAuditLogController {
 	/**
 	 * @return
 	 */
-	@RequestMapping(VIEW_AUDIT_LOG_FORM)
+	@RequestMapping(value = VIEW_AUDIT_LOG_FORM, method = RequestMethod.GET)
 	public void showForm(ModelMap model) {
 		if (log.isDebugEnabled()) {
 			log.debug("Fetching audit log entries...");


### PR DESCRIPTION
## JIRA
[AUDIT-42](https://openmrs.atlassian.net/browse/AUDIT-42)

## Description
There was no constraint on the `@RequestMapping(VIEW_AUDIT_LOG_FORM)` for `method`. As such, all POST, PUT, and DELETE requests were going to the read-only method in Spring MVC. The new constraint of `method=RequestMethod.GET` fixes this issue.

## Testing Steps
1. Make a POST request to `/module/auditlog/viewAuditLog` and expect a 405 response code.
2. Make a GET request

[AUDIT-42]: https://openmrs.atlassian.net/browse/AUDIT-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ