### PR TITLE
AUDIT-44: extend count endpoint to support filtering by object type

### DIFF
--- a/api/src/main/java/org/openmrs/module/auditlog/api/AuditLogService.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/api/AuditLogService.java
@@ -143,7 +143,7 @@ public interface AuditLogService extends OpenmrsService {
 	
 	/**
 	 * Gets all audit logs for the object that match the other specified arguments
-	 * 
+	 *
 	 * @param object the uuid of the object to match against
 	 * @param actions the actions to match against
 	 * @param startDate the start date to match against
@@ -156,4 +156,19 @@ public interface AuditLogService extends OpenmrsService {
 	@Authorized(AuditLogConstants.PRIV_GET_AUDITLOGS)
 	public List<AuditLog> getAuditLogs(Object object, List<Action> actions, Date startDate, Date endDate,
 	                                   boolean excludeChildAuditLogs);
+
+	/**
+	 * Returns the total number of audit log entries matching the specified arguments, without
+	 * applying pagination. Useful for building paged UIs that need a total-count header.
+	 *
+	 * @param clazzes the class types to match against
+	 * @param actions the list of {@link Action}s to match against
+	 * @param startDate lower bound for date_created (inclusive)
+	 * @param endDate upper bound for date_created (inclusive)
+	 * @param excludeChildAuditLogs if true, child logs for collection items are excluded
+	 * @return the total count of matching audit log entries
+	 */
+	@Authorized(AuditLogConstants.PRIV_GET_AUDITLOGS)
+	public long countAuditLogs(List<Class<?>> clazzes, List<Action> actions, Date startDate, Date endDate,
+	                           boolean excludeChildAuditLogs);
 }

--- a/api/src/main/java/org/openmrs/module/auditlog/api/db/AuditLogDAO.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/api/db/AuditLogDAO.java
@@ -94,9 +94,23 @@ public interface AuditLogDAO {
 	public <T> T getObjectByUuid(Class<T> clazz, String uuid);
 	
 	/**
+	 * Returns the total number of audit log entries matching the specified arguments, without
+	 * applying any pagination.
+	 *
+	 * @param types the class names to match against
+	 * @param actions the list of {@link Action}s to match against
+	 * @param startDate lower bound for date_created (inclusive)
+	 * @param endDate upper bound for date_created (inclusive)
+	 * @param excludeChildAuditLogs if true, only top-level logs are counted
+	 * @return the total count of matching audit log entries
+	 */
+	public long countAuditLogs(List<Class<?>> types, List<Action> actions, Date startDate, Date endDate,
+	                           boolean excludeChildAuditLogs);
+
+	/**
 	 * Returns true or false depending on the value of the
 	 * AuditLogConstants#GP_STORE_LAST_STATE_OF_DELETED_ITEMS global property
-	 * 
+	 *
 	 * @return true is allowed otherwise false
 	 */
 	public boolean storeLastStateOfDeletedItems();

--- a/api/src/main/java/org/openmrs/module/auditlog/api/db/hibernate/HibernateAuditLogDAO.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/api/db/hibernate/HibernateAuditLogDAO.java
@@ -26,6 +26,7 @@ import org.hibernate.Criteria;
 import org.hibernate.EntityMode;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Order;
+import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.GlobalPropertyListener;
@@ -129,6 +130,35 @@ public class HibernateAuditLogDAO implements AuditLogDAO, GlobalPropertyListener
 		criteria.addOrder(Order.desc("dateCreated"));
 
 		return criteria.list();
+	}
+
+	/**
+	 * @see AuditLogDAO#countAuditLogs(List, List, Date, Date, boolean)
+	 */
+	@Override
+	public long countAuditLogs(List<Class<?>> types, List<Action> actions, Date startDate, Date endDate,
+	                           boolean excludeChildAuditLogs) {
+		Criteria criteria = sessionFactory.getCurrentSession().createCriteria(AuditLog.class);
+		if (types != null) {
+			List<String> classNames = types.stream()
+					.map(Class::getName)
+					.collect(Collectors.toList());
+			criteria.add(Restrictions.in("type", classNames));
+		}
+		if (actions != null) {
+			criteria.add(Restrictions.in("action", actions));
+		}
+		if (excludeChildAuditLogs) {
+			criteria.add(Restrictions.isNull("parentAuditLog"));
+		}
+		if (startDate != null) {
+			criteria.add(Restrictions.ge("dateCreated", startDate));
+		}
+		if (endDate != null) {
+			criteria.add(Restrictions.le("dateCreated", endDate));
+		}
+		criteria.setProjection(Projections.rowCount());
+		return (Long) criteria.uniqueResult();
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/auditlog/api/impl/AuditLogServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/auditlog/api/impl/AuditLogServiceImpl.java
@@ -165,4 +165,24 @@ public class AuditLogServiceImpl extends BaseOpenmrsService implements AuditLogS
 	                                   boolean excludeChildAuditLogs) {
 		return getAuditLogs(dao.getId(object), object.getClass(), actions, startDate, endDate, excludeChildAuditLogs);
 	}
+
+	/**
+	 * @see AuditLogService#countAuditLogs(List, List, Date, Date, boolean)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public long countAuditLogs(List<Class<?>> clazzes, List<Action> actions, Date startDate, Date endDate,
+	                           boolean excludeChildAuditLogs) {
+		List<Class<?>> classesToMatch = null;
+		if (clazzes != null) {
+			classesToMatch = new ArrayList<Class<?>>();
+			for (Class clazz : clazzes) {
+				classesToMatch.add(clazz);
+				for (Class subclass : DAOUtils.getPersistentConcreteSubclasses(clazz)) {
+					classesToMatch.add(subclass);
+				}
+			}
+		}
+		return dao.countAuditLogs(classesToMatch, actions, startDate, endDate, excludeChildAuditLogs);
+	}
 }

--- a/omod/src/main/java/org/openmrs/module/auditlog/web/controller/AuditLogCountController.java
+++ b/omod/src/main/java/org/openmrs/module/auditlog/web/controller/AuditLogCountController.java
@@ -1,0 +1,125 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.auditlog.web.controller;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.auditlog.AuditLog.Action;
+import org.openmrs.module.auditlog.api.AuditLogService;
+import org.openmrs.module.auditlog.util.AuditLogConstants;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * AUDIT-40/AUDIT-44: REST endpoint returning the total count of audit log entries matching the
+ * given filters, without pagination overhead.
+ *
+ * <p>GET /module/auditlog/rest/auditlogs/count
+ *
+ * <p>Supported query parameters:
+ * <ul>
+ *   <li>{@code type}      – fully-qualified class name, e.g. org.openmrs.Concept</li>
+ *   <li>{@code action}    – comma-separated actions: CREATED, UPDATED, DELETED</li>
+ *   <li>{@code startDate} – inclusive lower bound (yyyy-MM-dd)</li>
+ *   <li>{@code endDate}   – inclusive upper bound (yyyy-MM-dd)</li>
+ * </ul>
+ *
+ * <p>Example response: {@code {"count": 142}}
+ */
+@Controller
+@RequestMapping("/module/auditlog/rest")
+public class AuditLogCountController {
+
+	private static final Log log = LogFactory.getLog(AuditLogCountController.class);
+
+	private static final String DATE_FORMAT = "yyyy-MM-dd";
+
+	@RequestMapping(value = "/auditlogs/count", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@ResponseBody
+	public ResponseEntity<?> countAuditLogs(
+	        @RequestParam(value = "type", required = false) String typeParam,
+	        @RequestParam(value = "action", required = false) String actionParam,
+	        @RequestParam(value = "startDate", required = false) String startDateParam,
+	        @RequestParam(value = "endDate", required = false) String endDateParam) {
+
+		Context.requirePrivilege(AuditLogConstants.PRIV_GET_AUDITLOGS);
+
+		List<Action> actions = parseActions(actionParam);
+		Date startDate = parseDate(startDateParam, "startDate");
+		Date endDate = parseDate(endDateParam, "endDate");
+
+		if (startDate != null && endDate != null && startDate.after(endDate)) {
+			return ResponseEntity.badRequest().body("{\"error\":\"startDate must not be after endDate\"}");
+		}
+
+		List<Class<?>> types = null;
+		if (StringUtils.isNotBlank(typeParam)) {
+			try {
+				types = Collections.<Class<?>>singletonList(Context.loadClass(typeParam));
+			}
+			catch (ClassNotFoundException e) {
+				return ResponseEntity.badRequest().body("{\"error\":\"Unknown type: " + typeParam + "\"}");
+			}
+		}
+
+		long count = Context.getService(AuditLogService.class)
+		        .countAuditLogs(types, actions, startDate, endDate, true);
+
+		return ResponseEntity.ok("{\"count\":" + count + "}");
+	}
+
+	private List<Action> parseActions(String actionParam) {
+		if (StringUtils.isBlank(actionParam)) {
+			return null;
+		}
+		List<Action> actions = new ArrayList<Action>();
+		for (String raw : actionParam.split(",")) {
+			String trimmed = raw.trim().toUpperCase();
+			try {
+				actions.add(Action.valueOf(trimmed));
+			}
+			catch (IllegalArgumentException e) {
+				log.warn("Ignoring unrecognised action value: " + trimmed);
+			}
+		}
+		return actions.isEmpty() ? null : actions;
+	}
+
+	private Date parseDate(String dateParam, String fieldName) {
+		if (StringUtils.isBlank(dateParam)) {
+			return null;
+		}
+		try {
+			return new SimpleDateFormat(DATE_FORMAT).parse(dateParam);
+		}
+		catch (ParseException e) {
+			log.warn("Invalid " + fieldName + " value '" + dateParam + "', expected " + DATE_FORMAT);
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
## JIRA
[AUDIT-44](https://openmrs.atlassian.net/browse/AUDIT-44)

## Description
This feature will add functionality to the count endpoint that was created in AUDIT-40 by adding a `type` parameter that allows you to specify a specific type (by its fully qualified class name). For example, `org.openmrs.Concept`. If the specified class is not available, then a 400 is returned with a descriptive message.

## Steps to Test
1. Try `/module/auditlog/rest/auditlogs/count?type=org

[AUDIT-44]: https://openmrs.atlassian.net/browse/AUDIT-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ