### PR TITLE
AUDIT-35: escape user-controlled values in viewAuditLog.jsp to fix XSS

### DIFF
--- a/omod/src/main/webapp/viewAuditLog.jsp
+++ b/omod/src/main/webapp/viewAuditLog.jsp
@@ -39,7 +39,7 @@
                          src="<openmrs:contextPath />/moduleResources/${moduleId}/images/${auditLog.action}.gif" />
                 </td>
                 <td>
-                    ${auditLog.simpleTypeName}
+                    <c:out value="${auditLog.simpleTypeName}" />
                     <c:if test="${fn:length(auditLog.childAuditLogs) > 0}"> (${fn:length(auditLog.childAuditLogs)})</c:if>
                 </td>
                 <td>
@@ -49,7 +49,7 @@
                             <spring:message code="${moduleId}.systemAction" />
                         </c:when>
                         <c:otherwise>
-                            ${auditLog.user.personName} <c:if test="${fn:trim(auditLog.user.username) != ''}">[${auditLog.user.username}]</c:if>
+                            <c:out value="${auditLog.user.personName}" /> <c:if test="${fn:trim(auditLog.user.username) != ''}">[<c:out value="${auditLog.user.username}" />]</c:if>
                         </c:otherwise>
                     </c:choose>
                 </td>


### PR DESCRIPTION
## JIRA
[AUDIT-35](https://openmrs.atlassian.net/browse/AUDIT-35)

## Description
Three raw EL expressions in `viewAuditLog.jsp` rendered user-controlled data directly into HTML without escaping:

- `${auditLog.simpleTypeName}`
- `${auditLog.user.personName}`
- `${auditLog.user.username}`

The `spring:htmlEscape` directive in `include.jsp` only covers `<spring:message>` tags — it does NOT escape raw `${...}` EL expressions. An attacker with access to create objects with crafted names could inject arbitrary HTML/JavaScript into the audit log view.

## Fix
Replaced all three with `<c:out value="..."/>` which HTML-escapes output by default.

## How to test
1. Create an audited object with a name containing `<script>alert(1)</script>`
2. Open the audit log view
3. Verify the script tag is rendered as plain text, not executed

[AUDIT-35]: https://openmrs.atlassian.net/browse/AUDIT-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ